### PR TITLE
Improve CSV output

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,9 @@
 """Streamlit interface for Rakuten scraper."""
 import asyncio
 import streamlit as st
+from pathlib import Path
 
-from main import run, save_csv, Product
+from main import run, save_csv, Product, generate_csv_path
 
 st.title("Rakuten Scraper")
 keyword = st.text_input("検索キーワード")
@@ -14,9 +15,11 @@ if run_button and keyword:
     products = asyncio.run(run(keyword, skip_shop))
     if products:
         st.write(f"{len(products)} 商品が見つかりました")
-        # Display table
         st.table([{"商品名": p.name, "店舗名": p.shop, "URL": p.url} for p in products])
-        save_csv(products, "result.csv")
-        st.success("result.csv を保存しました")
+        path = generate_csv_path(keyword, skip_shop)
+        save_csv(products, path)
+        st.success(f"{Path(path).name} を保存しました")
+        with open(path, "rb") as f:
+            st.download_button("CSVをダウンロード", f, file_name=Path(path).name)
     else:
         st.write("該当する商品がありませんでした")

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@
 This script searches Rakuten for a given keyword and extracts product URL,
 product name and store name from the search results. Results from a
 specified store can be skipped. Progress is logged to stdout. The scraped
-results are saved into ``result.csv``.
+results are saved into the ``results`` folder with a timestamped file name.
 
 Note: Network access might be blocked in this environment, so the scraper
 may fail to fetch pages when executed here.
@@ -15,18 +15,44 @@ import csv
 import logging
 import sys
 import urllib.parse
+import datetime
+import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import List
 
 from playwright.async_api import async_playwright, Page
 
 SEARCH_URL = "https://search.rakuten.co.jp/search/mall/{query}/"
 
+# Directory where CSV files are saved
+RESULTS_DIR = Path("results")
+
+# Configure logging to output detailed progress information
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+    handlers=[
+        logging.FileHandler("scraper.log", encoding="utf-8"),
+        logging.StreamHandler()
+    ],
+)
+
 @dataclass
 class Product:
     url: str
     name: str
     shop: str
+
+
+def generate_csv_path(keyword: str, shop: str) -> str:
+    """Return path for CSV file based on keyword, shop and current time."""
+    timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M")
+    safe_keyword = keyword.replace(" ", "_")
+    safe_shop = shop.replace(" ", "_") if shop else "none"
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    filename = f"{safe_keyword}_{safe_shop}_{timestamp}.csv"
+    return str(RESULTS_DIR / filename)
 
 async def scrape_page(page: Page, keyword: str, skip_shop: str) -> List[Product]:
     """Scrape Rakuten search results for ``keyword`` skipping ``skip_shop``."""
@@ -38,10 +64,13 @@ async def scrape_page(page: Page, keyword: str, skip_shop: str) -> List[Product]
     items = await page.query_selector_all("div.searchresultitem")
     products: List[Product] = []
     logging.info("Found %d items", len(items))
-    for item in items:
+    for idx, item in enumerate(items, 1):
+        logging.info("Processing item %d/%d", idx, len(items))
         link = await item.query_selector("h2 > a")
-        shop_el = await item.query_selector(".searchresultitem__shop")
+        # Store name link is wrapped in an anchor with class '_ellipsis'
+        shop_el = await item.query_selector("a._ellipsis")
         if not link or not shop_el:
+            logging.warning("Missing link or shop element; skipping item %d", idx)
             continue
         name = (await link.inner_text()).strip()
         href = await link.get_attribute("href")
@@ -51,17 +80,24 @@ async def scrape_page(page: Page, keyword: str, skip_shop: str) -> List[Product]
             continue
         products.append(Product(url=href or "", name=name, shop=shop))
         logging.info("Collected %s from %s", name, shop)
+    logging.info("Finished scraping %d products", len(products))
     return products
 
 async def run(keyword: str, skip_shop: str) -> List[Product]:
+    logging.info("Starting run with keyword=%s skip_shop=%s", keyword, skip_shop)
     async with async_playwright() as p:
+        logging.info("Launching browser")
         browser = await p.firefox.launch(headless=True)
         page = await browser.new_page()
+        logging.info("Browser launched")
         products = await scrape_page(page, keyword, skip_shop)
         await browser.close()
+        logging.info("Browser closed")
+        logging.info("Collected %d products", len(products))
         return products
 
 def save_csv(products: List[Product], path: str) -> None:
+    logging.info("Saving results to %s", path)
     with open(path, "w", newline="", encoding="utf-8-sig") as f:
         writer = csv.writer(f)
         writer.writerow(["商品名", "店舗名", "URL"])
@@ -77,12 +113,10 @@ def main() -> None:
     keyword = sys.argv[1]
     skip_shop = sys.argv[2]
 
-
-    html = fetch_html(keyword)
-    all_products = parse_products(html)
-    filtered = [p for p in all_products if p.shop != skip_shop]
-    save_csv(filtered, "result.csv")
-    print(f"Saved {len(filtered)} products to result.csv")
+    products = asyncio.run(run(keyword, skip_shop))
+    path = generate_csv_path(keyword, skip_shop)
+    save_csv(products, path)
+    print(f"Saved {len(products)} products to {path}")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- store results in a `results` folder using keyword, shop name and timestamp
- expose `generate_csv_path` helper for the Streamlit UI
- add CSV download button in Streamlit
- clean up CLI to use the async scraper directly

## Testing
- `python -m py_compile main.py app.py`
- `python main.py test_shop some_shop` *(fails: ModuleNotFoundError: No module named 'playwright')*