### PR TITLE
Add batch processing utility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,5 @@ ENV/
 htmlcov/
 
 # その他
-.DS_Store 
+.DS_Store
+results/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Rakuten Scraper
+
+This repository contains a Playwright based scraper for Rakuten searches.
+
+## Batch Processing
+
+`batch.py` reads a CSV file with columns `ID`, `キーワード` (keyword), and `店舗名` (shop). For each row it performs a search and saves the results into a folder named after `ID` under `results/`.
+
+Usage:
+
+```bash
+python batch.py INPUT_CSV
+```
+
+The script will create a CSV file for each row with a timestamp in the file name.

--- a/batch.py
+++ b/batch.py
@@ -1,0 +1,48 @@
+import asyncio
+import csv
+from pathlib import Path
+import sys
+
+from main import run, save_csv, generate_csv_path, Product
+
+
+def filter_by_shop(products, shop):
+    """Return only products sold by ``shop``. If shop is falsy, return products."""
+    if not shop:
+        return products
+    filtered = [p for p in products if shop in p.shop]
+    return filtered
+
+
+async def process_row(row):
+    id_ = row.get("ID") or row.get("id")
+    keyword = row.get("キーワード") or row.get("keyword")
+    shop = row.get("店舗名") or row.get("shop")
+    if not id_ or not keyword:
+        print("Row is missing required columns:", row)
+        return
+
+    products = await run(keyword, "")
+    products = filter_by_shop(products, shop)
+    results_dir = Path("results") / str(id_)
+    path = generate_csv_path(keyword, shop or "", results_dir)
+    save_csv(products, path)
+    print(f"Saved {len(products)} products to {path}")
+
+
+async def process_csv(file_path):
+    with open(file_path, newline="", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            await process_row(row)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: batch.py INPUT_CSV")
+        return
+    asyncio.run(process_csv(sys.argv[1]))
+
+
+if __name__ == "__main__":
+    main()

--- a/main.py
+++ b/main.py
@@ -52,14 +52,18 @@ class Product:
 
 
 
-def generate_csv_path(keyword: str, shop: str) -> str:
-    """Return path for CSV file based on keyword, shop and current time."""
+def generate_csv_path(keyword: str, shop: str, results_dir: Path = RESULTS_DIR) -> str:
+    """Return path for CSV file based on keyword, shop and current time.
+
+    ``results_dir`` specifies the directory where the CSV file will be
+    created. By default, it uses ``RESULTS_DIR``.
+    """
     timestamp = datetime.datetime.now().strftime("%Y%m%d%H%M")
     safe_keyword = keyword.replace(" ", "_")
     safe_shop = shop.replace(" ", "_") if shop else "none"
-    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
     filename = f"{safe_keyword}_{safe_shop}_{timestamp}.csv"
-    return str(RESULTS_DIR / filename)
+    return str(results_dir / filename)
 
 async def scrape_page(page: Page, keyword: str, skip_shop: str) -> List[Product]:
     """Scrape Rakuten search results for ``keyword`` skipping ``skip_shop``."""


### PR DESCRIPTION
## Summary
- enhance `generate_csv_path` to allow custom output directories
- add `batch.py` for processing CSV files with IDs, keywords and shops
- ignore generated `results/` folder
- document batch processing usage

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python batch.py` *(fails: ModuleNotFoundError: No module named 'playwright')*